### PR TITLE
FIX Dockerfile with RDTTools

### DIFF
--- a/affiliation_otu/affiliation_otu_0.9.0/Dockerfile
+++ b/affiliation_otu/affiliation_otu_0.9.0/Dockerfile
@@ -41,8 +41,11 @@ RUN git clone https://github.com/rdpstaff/RDPTools.git && \
     git checkout $TOOL_VERSION && \
     git submodule update --init && \
     make  && \
-    cp lib/*.jar /usr/local/bin/
+    cp *.jar /usr/local/bin/
 
+
+# Copy dependencies for RDPTools
+RUN cp -r ${TOOL_NAME}*/lib /usr/local/bin/
 
 # Install AffiliationOTU 
 COPY bin/* /usr/local/bin/

--- a/rdptools/rdptools_2.0.2/Dockerfile
+++ b/rdptools/rdptools_2.0.2/Dockerfile
@@ -41,8 +41,10 @@ RUN git clone https://github.com/rdpstaff/RDPTools.git && \
     git checkout $TOOL_VERSION && \
     git submodule update --init && \
     make  && \
-    cp lib/*.jar /usr/local/bin/
+    cp *.jar /usr/local/bin/
 
+# Copy dependencies for RDPTools
+RUN cp -r ${TOOL_NAME}*/lib /usr/local/bin/
 
 # Make script executable
 RUN chmod +x /usr/local/bin/*


### PR DESCRIPTION
FIX Dockerfile with RDTTools: missing dependencies on RDPTools in Dockerfile for RDPTools and affiliation OTU tool.
